### PR TITLE
Updated schema so that we can now query by school_id

### DIFF
--- a/graphql/resolvers.js
+++ b/graphql/resolvers.js
@@ -8,6 +8,9 @@ const resolvers = {
         school: (parent, {id}) => {
             return db('schools').where({id}).first()
         },
+        schoolBySchoolId: (parent, {school_id}) => {
+            return db('schools').where({school_id}).first()   
+        },
         allCategories: () => {
             return db('categories')
         },

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -33,6 +33,7 @@ const typeDefs = gql`
     type Query {
         allSchools: [School!]!
         school(id: ID!): School!
+        schoolBySchoolId (school_id: ID!): School!
         allCategories: [Category!]!
         category(id: ID!): Category!
         allArts: [Art!]!


### PR DESCRIPTION
Updated schema so that we can now query by school_id, which is the firebase uid saved in our database.

Co-authored-by: David Inden <davidinden@gmail.com>
Co-authored-by: Grissobel Payonk <grissobel.castro@gmail.com>
Co-authored-by: Ian Schwartz <ian.schwartz23@gmail.com>
Co-authored-by: Jason Loomis <jason@jrloomis.com>
Co-authored-by: Ami Scott <amiezrascott@gmail.com>

# Description

Fixes the issue of not being able to query by school id, where we currently can query from the school's primary key. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- Manually tested

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
